### PR TITLE
fix for No module named 'openai' error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 langchain
 chainlit
+openai


### PR DESCRIPTION
error:
```
$ chainlit run langchain_gemma_ollama.py
Traceback (most recent call last):
  File "/private/tmp/.venv/bin/chainlit", line 5, in <module>
    from chainlit.cli import cli
  File "/private/tmp/.venv/lib/python3.11/site-packages/chainlit/__init__.py", line 22, in <module>
    import chainlit.input_widget as input_widget
  File "/private/tmp/.venv/lib/python3.11/site-packages/chainlit/input_widget.py", line 5, in <module>
    from chainlit.types import InputWidgetType
  File "/private/tmp/.venv/lib/python3.11/site-packages/chainlit/types.py", line 10, in <module>
    from literalai import ChatGeneration, CompletionGeneration
  File "/private/tmp/.venv/lib/python3.11/site-packages/literalai/__init__.py", line 1, in <module>
    from .client import LiteralClient
  File "/private/tmp/.venv/lib/python3.11/site-packages/literalai/client.py", line 4, in <module>
    from literalai.api import API
  File "/private/tmp/.venv/lib/python3.11/site-packages/literalai/api.py", line 11, in <module>
    from literalai.helper import ensure_values_serializable
  File "/private/tmp/.venv/lib/python3.11/site-packages/literalai/helper.py", line 1, in <module>
    from openai.types.chat import ChatCompletionMessage
ModuleNotFoundError: No module named 'openai'
```